### PR TITLE
Simplify dockerfile, new wrapper script, add docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM ubuntu as builder
+FROM debian:jessie-slim as builder
 ARG DEBIAN_FRONTEND=noninteractive
+
 # lmgrd bin files download from MATLAB website comes with wrong interpreter
 # we do manual patch here
 RUN apt update && apt install wget unzip patchelf -y && mkdir /lmgrd \
@@ -8,13 +9,7 @@ RUN apt update && apt install wget unzip patchelf -y && mkdir /lmgrd \
 	&& for file in $(ls etc/glnxa64); do patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 etc/glnxa64/${file}; done \
 	&& rm -vf mathworks_network_license_manager_glnxa64.zip
 
-FROM ubuntu
+FROM debian:jessie-slim
 COPY --from=builder /lmgrd /lmgrd
-VOLUME /etc/lmgrd/licenses
-VOLUME /usr/tmp
-ENV LMGRD_PORT=27000
-ENV MLM_PORT=27001
-EXPOSE $LMGRD_PORT
-EXPOSE $MLM_PORT
 
-ENTRYPOINT ["/lmgrd/etc/glnxa64/lmgrd", "-z", "-c", "/etc/lmgrd/licenses"]
+ENTRYPOINT ["env", "/lmgrd/etc/glnxa64/lmgrd", "-z"]

--- a/README.md
+++ b/README.md
@@ -1,24 +1,68 @@
 # Docker image for MATLAB license manager (lmgrd)
 
-This repo hosts the Dockerfile for running lmgrd. To run a container:
+This repo hosts the Dockerfile for running `lmgrd` - the Matlab licenses manager. Below is the `run.sh` wrapper script you may need to edit:
 
-```shell
-docker run -itd --user nobody --hostname HOSTNAME --env LMGRD_PORT=27000 --env MLM_PORT=27001 -p 27000:27000 -p 27001:27001 -v LICENSEDIR:/etc/lmgrd/licenses --mac-address MAC butui/lmgrd
+```sh
+#!/bin/bash
+
+MY_HOSTNAME=#YOUR HOSTNAME HERE
+MY_MAC=#YOUR MAC HERE
+MY_LMGRD_PORT=27000
+MY_MLM_PORT=27001
+
+# MY_LICENSE_ROOT is where you store license files on the host
+MY_LICENSE_ROOT="/etc/lmgrd/licenses"
+# MY_LICENSE_FILE is license file you want to use relative to MY_LICENSE_ROOT
+MY_LICENSE_FILE="matlab/license.dat"
+
+docker run -it --rm --user nobody --hostname ${MY_HOSTNAME}         \
+    --env LMGRD_PORT=${MY_LMGRD_PORT} --env MLM_PORT=${MY_MLM_PORT} \
+    -p ${MY_LMGRD_PORT}:${MY_LMGRD_PORT}                            \
+    -p ${MY_MLM_PORT}:${MY_MLM_PORT}                                \
+    --env LM_LICENSE_FILE="/etc/lmgrd/licenses/${MY_LICENSE_FILE}"  \
+    -v ${MY_LICENSE_ROOT}:"/etc/lmgrd/licenses"                     \
+    -v "/usr/tmp":"/usr/tmp"                                        \
+    --mac-address ${MY_MAC} butui/lmgrd
+
 ```
 
-where `HOSTNAME` is the hostname of the container, MAC is the MAC address of the container. And this Docker image use `27000` and `27001` port for `lmgrd` and `MLM` by default. You could modify these ports by setting the environment variable `LMGRD_PORT` and `MLM_PORT` without manual modify the `Dockerfile` or the license file. These values should meet the value in your license file. Your license file should contain two lines like this:
+| Variable      | Meaning                                                      |
+| ------------- | ------------------------------------------------------------ |
+| `MY_HOSTNAME` | Any hostname, must match license file SERVER line. Suggest `lmgrd`. See below |
+| `MY_MAC`      | The MAC address registered to Mathworks for the server. This must match. |
+
+We chose to use `27000` and `27001` port for `lmgrd` and `MLM` by default. These values should meet the value in your license file. 
+
+## Building a Matlab License File
+
+Your `lmgrd` container will use a single license file. In example variables in `run.sh`, the license file would be located at `/etc/lmgrd/licenses/matlab/license.dat`. It must contain at least three lines like this:
 
 ```text
-SERVER lmgrd 486775754811 27000
-DAEMON MLM "/lmgrd/etc/glnxa64/MLM" port=27001
+SERVER <HOSTNAME> <MAC> <LMGRD PORT>
+DAEMON MLM "/lmgrd/etc/glnxa64/MLM" port=<MLM PORT>
+VENDOR MLM "mlm.opt"
 ```
 
-For further explanation, refer to the [manual](https://www.mathworks.com/matlabcentral/answers/uploaded_files/5871/LicenseAdministration.pdf). `LICENSEDIR` is where you store your license manager. You could easily update the license file without rebuild the Docker image. You might need to restart the Docker container if needed.
+Where these variables (in `<>`) match what you supplied in the `run.sh` script. 
 
-For client who need to use this lmgrd, they could use a simple license file:
+Next, you need to copy the contents of your Mathworks `license.lic` which you download from the "Activation Details for Matlab License Server" page. I simply put these three lines at the very top before the comments which start with `# BEGIN----`
+
+Next, you need to copy your `mlm.opt` file next to your `license.dat` file. In example variables in `run.sh`, the mlm.opt file would be located at `/etc/lmgrd/licenses/matlab/mlm.opt`.
+
+For further explanation, refer to the [manual](https://www.mathworks.com/matlabcentral/answers/uploaded_files/5871/LicenseAdministration.pdf).
+
+For client who need to use this `lmgrd`, they could use a simple license file:
 
 ```text
-SERVER 192.168.99.10 INTERNET=192.168.99.10 27000
+SERVER <IP or HOSTNAME> INTERNET=<IP or HOSTNAME> 27000
 USE_SERVER
 ```
 
+Where `IP or HOSTNAME` is the IP address of the server running this docker image.
+
+We've also seen success via
+
+```txt
+SERVER <IP or HOSTNAME> <MAC of container> 27000
+USE_SERVER
+```

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+MY_HOSTNAME=#YOUR HOSTNAME HERE
+MY_MAC=#YOUR MAC HERE
+MY_LMGRD_PORT=27000
+MY_MLM_PORT=27001
+
+# MY_LICENSE_ROOT is where you store license files on the host
+MY_LICENSE_ROOT="/etc/lmgrd/licenses"
+# MY_LICENSE_FILE is license file you want to use relative to MY_LICENSE_ROOT
+MY_LICENSE_FILE="matlab/license.dat"
+
+docker run -it --rm --user nobody --hostname ${MY_HOSTNAME}         \
+    --env LMGRD_PORT=${MY_LMGRD_PORT} --env MLM_PORT=${MY_MLM_PORT} \
+    -p ${MY_LMGRD_PORT}:${MY_LMGRD_PORT}                            \
+    -p ${MY_MLM_PORT}:${MY_MLM_PORT}                                \
+    --env LM_LICENSE_FILE="/etc/lmgrd/licenses/${MY_LICENSE_FILE}"  \
+    -v ${MY_LICENSE_ROOT}:"/etc/lmgrd/licenses"                     \
+    -v "/usr/tmp":"/usr/tmp"                                        \
+    --mac-address ${MY_MAC} butui/lmgrd


### PR DESCRIPTION
* Moved to debian:jessie-slim to reduce image size
* Removed parsing `ls` output which is not suggested
* Removed VOLUME and EXPOSE from Dockerfile since we need to supply that
  in the `docker run` command anyway.
* Created wrapper script to easily export variables
* Updated README to include MLM.opt stuff
* Updated README to include variable descriptions and license file
  descriptions.